### PR TITLE
Fix createRouter argument type.

### DIFF
--- a/lib/express.d.ts
+++ b/lib/express.d.ts
@@ -14,6 +14,7 @@ declare namespace createApplication {
     export type CookieOptions = _CookieOptions
     export type Application = _Application
     export type Router = createRouter.Router
+    export type RouterOptions = createRouter.RouterOptions
     export type RequestHandler = createRouter.RequestHandler
     export type ErrorHandler = createRouter.ErrorHandler
     export type ParamHandler = createRouter.ParamHandler

--- a/lib/router/index.d.ts
+++ b/lib/router/index.d.ts
@@ -283,5 +283,5 @@ declare namespace createRouter {
     }
 }
 
-declare function createRouter(options? : {caseSensitive?: boolean; mergeParams?: boolean; strict?: boolean}): createRouter.Router;
+declare function createRouter(options?: {caseSensitive?: boolean; mergeParams?: boolean; strict?: boolean}): createRouter.Router;
 export = createRouter;

--- a/lib/router/index.d.ts
+++ b/lib/router/index.d.ts
@@ -283,5 +283,5 @@ declare namespace createRouter {
     }
 }
 
-declare function createRouter(): createRouter.Router;
+declare function createRouter(options? : {caseSensitive?: boolean; mergeParams?: boolean; strict?: boolean}): createRouter.Router;
 export = createRouter;

--- a/lib/router/index.d.ts
+++ b/lib/router/index.d.ts
@@ -28,6 +28,12 @@ declare namespace createRouter {
         (req: Request, res: Response, next: NextFunction, value: any, name: string): any;
     }
 
+    export interface Options {
+        caseSensitive?: boolean;
+        mergeParams?: boolean;
+        strict?: boolean;
+    }
+
     export interface Router extends RequestHandler {
 
         /**
@@ -283,5 +289,5 @@ declare namespace createRouter {
     }
 }
 
-declare function createRouter(options?: {caseSensitive?: boolean; mergeParams?: boolean; strict?: boolean}): createRouter.Router;
+declare function createRouter(options?: createRouter.Options): createRouter.Router;
 export = createRouter;

--- a/lib/router/index.d.ts
+++ b/lib/router/index.d.ts
@@ -28,7 +28,7 @@ declare namespace createRouter {
         (req: Request, res: Response, next: NextFunction, value: any, name: string): any;
     }
 
-    export interface Options {
+    export interface RouterOptions {
         caseSensitive?: boolean;
         mergeParams?: boolean;
         strict?: boolean;
@@ -289,5 +289,5 @@ declare namespace createRouter {
     }
 }
 
-declare function createRouter(options?: createRouter.Options): createRouter.Router;
+declare function createRouter(options?: createRouter.RouterOptions): createRouter.Router;
 export = createRouter;

--- a/test/router-options.ts
+++ b/test/router-options.ts
@@ -1,0 +1,10 @@
+
+import {Router} from 'express';
+
+const router = Router({
+    caseSensitive: true,
+    mergeParams: true,
+    strict: true
+});
+
+export default router;

--- a/test/router-options.ts
+++ b/test/router-options.ts
@@ -1,10 +1,12 @@
 
-import {Router} from 'express';
+import {Router, RouterOptions} from 'express';
 
-const router = Router({
+const options: RouterOptions = {
     caseSensitive: true,
     mergeParams: true,
     strict: true
-});
+};
+
+const router = Router(options);
 
 export default router;

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -12,6 +12,7 @@
     "middleware.ts",
     "params.ts",
     "router.ts",
+    "router-options.ts",
     "static.ts"
   ]
 }


### PR DESCRIPTION
This PR provides for be able to add options object to `express.Router()` argument.
ex) `express.Router({caseSensitive: true})`.
Express API Doc: [express.Router options object](https://expressjs.com/en/4x/api.html#express).
