### PR TITLE
Fix up `express()` return type

### DIFF
--- a/lib/application.d.ts
+++ b/lib/application.d.ts
@@ -1,12 +1,10 @@
 
 import {Server} from 'http';
 import {ListenOptions} from 'net';
-import {EventEmitter} from 'events';
 import {Router, ParamHandler, HandlerArgument, PathArgument} from './router/index';
 
 declare namespace app {
-    export interface Application extends EventEmitter, Router {
-
+    export interface Application extends Router {
         /**
          * Contains one or more path patterns on which a sub-app was mounted.
          */

--- a/lib/express.d.ts
+++ b/lib/express.d.ts
@@ -1,4 +1,6 @@
 
+import {IncomingMessage, ServerResponse} from 'http';
+import {EventEmitter} from 'events';
 import {Application as _Application} from './application';
 import {Request as _Request} from './request';
 import {Response as _Response, CookieOptions as _CookieOptions} from './response';
@@ -21,12 +23,16 @@ declare namespace createApplication {
     export type Handler = createRouter.Handler
     export type NextFunction = createRouter.NextFunction
 
+    export interface Server extends Application, EventEmitter {
+        (req: IncomingMessage, res: ServerResponse, next?: (err?: Error) => void): void;
+    }
+
     // need to use an interface for this because `static` is a reserved word
     // and cannot be used as a variable identifier
     export interface Express {
 
         /** Create an express application. */
-        (): Application;
+        (): Server;
 
         /** The Application prototype */
         application: Application;

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "author": "Felix Becker <felix.b@outlook.com>",
   "license": "ISC",
   "devDependencies": {
-    "tslint": "^3.13.0",
-    "typescript": "^1.8.10",
-    "typings": "^1.3.1"
+    "tslint": "^4.3.1",
+    "typescript": "^2.1.5",
+    "typings": "^2.1.0"
   }
 }

--- a/test/app.ts
+++ b/test/app.ts
@@ -1,8 +1,11 @@
 
 import express = require('express');
+import {createServer} from 'http';
 import router from './router';
 
-const app: express.Application = express();
+const app = express();
+
+createServer(app).listen(3000);
 
 // requesthandler
 const requestHandler: express.RequestHandler = (req, res, next) => {

--- a/typings.json
+++ b/typings.json
@@ -1,16 +1,13 @@
 {
   "name": "express",
   "main": "index.d.ts",
+  "version": "4.14.0",
   "homepage": "https://github.com/types/npm-express",
   "dependencies": {
     "path-to-regexp": "github:pillarjs/path-to-regexp/index.d.ts#ec285ed3500aed455df59e3b8b07f473412918a4",
-    "serve-static": "registry:npm/serve-static#1.11.1+20160810053450"
+    "serve-static": "registry:npm/serve-static#1.11.1+20161113104247"
   },
-  "version": "4.14.0",
   "globalDependencies": {
-    "node": "registry:env/node#6.0.0+20160723033700"
-  },
-  "globalDevDependencies": {
-    "node": "registry:env/node#6.0.0+20160902022231"
+    "node": "registry:env/node#6.0.0+20170115054122"
   }
 }


### PR DESCRIPTION
Modifying the prototype is part of middleware in Express, that's how it accepts raw HTTP.

Closes https://github.com/types/npm-express/issues/18. 

@felixfbecker I tried to make the minimal amount of changes, the description of why is in the linked repo 😄 If this makes sense, feel free to merge and update the registry, hoping to use these changes soon because I've been messing around with refactoring the underlying HTTP layer.